### PR TITLE
Add missions API and store selected data in store

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,11 +12,14 @@
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
+        "axios": "^1.4.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-redux": "^8.0.5",
         "react-router-dom": "^6.11.2",
         "react-scripts": "5.0.1",
+        "redux": "^4.2.1",
+        "redux-logger": "^3.0.6",
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
@@ -5178,6 +5181,29 @@
         "node": ">=4"
       }
     },
+    "node_modules/axios": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
+      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/axobject-query": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-3.1.1.tgz",
@@ -6691,6 +6717,11 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
       "integrity": "sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA=="
+    },
+    "node_modules/deep-diff": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/deep-diff/-/deep-diff-0.3.8.tgz",
+      "integrity": "sha512-yVn6RZmHiGnxRKR9sJb3iVV2XTF1Ghh2DiWRZ3dMnGc43yUdWWF/kX6lQyk3+P84iprfWKU/8zFTrlkvtFm1ug=="
     },
     "node_modules/deep-equal": {
       "version": "2.2.1",
@@ -15161,6 +15192,11 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
     "node_modules/psl": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
@@ -16077,6 +16113,14 @@
       "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
       "dependencies": {
         "@babel/runtime": "^7.9.2"
+      }
+    },
+    "node_modules/redux-logger": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/redux-logger/-/redux-logger-3.0.6.tgz",
+      "integrity": "sha512-JoCIok7bg/XpqA1JqCqXFypuqBbQzGQySrhFzewB7ThcnysTO30l4VCst86AuB9T9tuT03MAA56Jw2PNhRSNCg==",
+      "dependencies": {
+        "deep-diff": "^0.3.5"
       }
     },
     "node_modules/redux-thunk": {

--- a/package.json
+++ b/package.json
@@ -7,11 +7,15 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
+    "axios": "^1.4.0",
+    "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-redux": "^8.0.5",
     "react-router-dom": "^6.11.2",
     "react-scripts": "5.0.1",
+    "redux": "^4.2.1",
+    "redux-logger": "^3.0.6",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/src/Components/Missions.jsx
+++ b/src/Components/Missions.jsx
@@ -1,5 +1,36 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import SingleMission from './SingleMission';
+import { allMissions, getMissionFromAPI, isLoading } from '../Redux/missionSlice';
 
-const Missions = () => <div>Missions</div>;
+const Missions = () => {
+  const missions = useSelector(allMissions);
+  const loading = useDispatch(isLoading);
 
+  const dispatch = useDispatch();
+  useEffect(() => {
+    if (missions.length === 0) {
+      dispatch(getMissionFromAPI());
+    }
+  }, [dispatch, loading, missions.length]);
+  return (
+    <section className="missionContainer">
+      <table className="missions">
+        <thead>
+          <tr>
+            <th>Mission</th>
+            <th>Description</th>
+            <th>Status</th>
+            <th> </th>
+          </tr>
+        </thead>
+        <tbody>
+          {missions.map((mission) => (
+            <SingleMission key={mission.id} mission={mission} />
+          ))}
+        </tbody>
+      </table>
+    </section>
+  );
+};
 export default Missions;

--- a/src/Components/SingleMission.jsx
+++ b/src/Components/SingleMission.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { useDispatch } from 'react-redux';
+import { joinedMission, leavedMission } from '../Redux/missionSlice'
+
+const SingleMission = ({ mission }) => {
+  const dispatch = useDispatch();
+  return (
+    <tr>
+      <td>{mission.missionName}</td>
+      <td>{mission.description}</td>
+      <td>
+        <div
+          className={mission?.joined ? 'member-badge active-mission' : 'member-badge'}
+        >
+          {mission?.joined ? 'Active Member' : 'NOT A MEMBER'}
+        </div>
+      </td>
+      <td>
+        <button
+          className={mission.joined ? 'leaveBtn' : 'joinBtn'}
+          type="button"
+          onClick={() => {
+            if (mission.joined) {
+              dispatch(leavedMission(mission.id));
+            } else {
+              dispatch(joinedMission(mission.id));
+            }
+          }}
+        >
+          {mission?.joined ? 'Leave Mission' : 'Join Mission'}
+        </button>
+      </td>
+    </tr>
+  );
+};
+
+SingleMission.propTypes = {
+  mission: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    missionName: PropTypes.string.isRequired,
+    description: PropTypes.string.isRequired,
+    joined: PropTypes.bool,
+  }).isRequired,
+};
+export default SingleMission;

--- a/src/Redux/missionSlice.jsx
+++ b/src/Redux/missionSlice.jsx
@@ -1,0 +1,66 @@
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
+import axios from 'axios';
+
+// Initial state
+const initialState = { missions: [], isLoading: false };
+const baseURL = 'https://api.spacexdata.com/v3/missions';
+
+// =============== Asynchronous =============
+
+export const getMissionFromAPI = createAsyncThunk(
+  'missions/getMissionFromAPI',
+  async (thunkAPI) => {
+    try {
+      const response = await axios.get(baseURL);
+      return response.data;
+    } catch (error) {
+      return thunkAPI.rejectWithValue('Something goes wrong.');
+    }
+  },
+);
+
+const missionSlice = createSlice({
+  initialState,
+  name: 'missions',
+  reducers: {
+    joinedMission: (state, action) => {
+      const newState = state.missions.map((mission) => {
+        if (mission.id === action.payload) {
+          return { ...mission, joined: true };
+        }
+        return mission;
+      });
+      return { ...state, missions: newState };
+    },
+    leavedMission: (state, action) => {
+      const newState = state.missions.map((mission) => {
+        if (mission.id === action.payload) {
+          return { ...mission, joined: false };
+        }
+        return mission;
+      });
+      return { ...state, missions: newState };
+    },
+  },
+  extraReducers: {
+    [getMissionFromAPI.fulfilled]: (state, action) => {
+      const missions = action.payload.map(
+        ({ mission_id: id, mission_name: missionName, description }) => ({
+          id,
+          missionName,
+          description,
+        }),
+      );
+      return { ...state, missions };
+    },
+    [getMissionFromAPI.rejected]: (state) => ({ ...state, isLoading: false }),
+  },
+});
+
+// Expose the state
+export const allMissions = (state) => state.missions.missions;
+export const isLoading = (state) => state.missions.isLoading;
+// Export the actions
+export const { joinedMission, leavedMission } = missionSlice.actions;
+// Export default the reducer
+export default missionSlice.reducer;

--- a/src/Redux/store.js
+++ b/src/Redux/store.js
@@ -1,8 +1,10 @@
 import { configureStore } from '@reduxjs/toolkit';
+import missionReducer from './missionSlice';
 
 const store = configureStore({
   reducer: {
     // Here we will be adding reducers
+    missions: missionReducer,
   },
 });
 

--- a/src/Routes/spaceRoutes.js
+++ b/src/Routes/spaceRoutes.js
@@ -12,7 +12,7 @@ const SpaceRoutes = () => (
       <Routes>
         <Route path="/" element={<Rockets />} />
         <Route path="/myProfile" element={<MyProfile />} />
-        <Route exact path="/missions" element={<Missions />} />
+        <Route path="/missions" element={<Missions />} />
         <Route path="/dragons" element={<h1>Dragons</h1>} />
       </Routes>
     </div>


### PR DESCRIPTION
In this pull request, I created and Implemented the following:
- Fetch data from the Missions endpoint (https://api.spacexdata.com/v3/missions) when a user navigates to the Missions section.

Once the data are fetched, I dispatched an action to store the selected data in the Redux store:

- mission_id
- mission_name
- description